### PR TITLE
Updated MOD file to fix the issue with the upcoming NEURON 9.0 release

### DIFF
--- a/01_GrC_2020_regular/mod_files/cdp5_CR.mod
+++ b/01_GrC_2020_regular/mod_files/cdp5_CR.mod
@@ -102,7 +102,7 @@ ASSIGNED {
 	vrat	(1)	
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/01_GrC_2020_regular/mod_files/cdp5_CR.mod
+++ b/01_GrC_2020_regular/mod_files/cdp5_CR.mod
@@ -98,11 +98,10 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/02_GrC_2020_mild_adapting/mod_files/cdp5_CR.mod
+++ b/02_GrC_2020_mild_adapting/mod_files/cdp5_CR.mod
@@ -102,7 +102,7 @@ ASSIGNED {
 	vrat	(1)	
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/02_GrC_2020_mild_adapting/mod_files/cdp5_CR.mod
+++ b/02_GrC_2020_mild_adapting/mod_files/cdp5_CR.mod
@@ -98,11 +98,10 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/03_GrC_2020_adapting/mod_files/cdp5_CR.mod
+++ b/03_GrC_2020_adapting/mod_files/cdp5_CR.mod
@@ -102,7 +102,7 @@ ASSIGNED {
 	vrat	(1)	
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/03_GrC_2020_adapting/mod_files/cdp5_CR.mod
+++ b/03_GrC_2020_adapting/mod_files/cdp5_CR.mod
@@ -98,11 +98,10 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/readme.html
+++ b/readme.html
@@ -87,4 +87,11 @@ https://www.humanbrainproject.eu/en/explore-the-brain/search/
 A Live Paper can be found on the HBP Brain Simulation Platform.
 <a href="https://collab.humanbrainproject.eu/#/collab/1655/nav/306845">https://collab.humanbrainproject.eu/#/collab/1655/nav/306845</a>
 
+
+Changelog
+---------
+
+cdp5*.mod files are updated due to issue mentioned in https://github.com/neuronsimulator/nrn/pull/1955.
+CONSTANT block has no effect in the initialization of ion variables.
+
 </pre></html>


### PR DESCRIPTION
USEION variable can not be initialized in a CONSTANT block.
See https://github.com/neuronsimulator/nrn/pull/1955.